### PR TITLE
Update jestConfig to support spec.js only

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eh-react-scripts",
-  "version": "3.3.0-13",
+  "version": "3.3.0-14",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -38,10 +38,10 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupFilesAfterEnv: setupTestsFile ? [setupTestsFile] : [],
     testMatch: process.env.TEST_MATCH
       ? [process.env.TEST_MATCH]
-      : ['<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}'],
+      : ['<rootDir>/src/**/?(*.)(spec).{js,ts}'],
     testEnvironment: 'jest-environment-jsdom-fourteen',
     transform: {
-      '^.+\\.(js|jsx|ts|tsx)$': isEjecting
+      '^.+\\.(js|ts )$': isEjecting
         ? '<rootDir>/node_modules/babel-jest'
         : resolve('config/jest/babelTransform.js'),
       '^.+\\.css$': resolve('config/jest/cssTransform.js'),


### PR DESCRIPTION
Since my previous PR, we now only running .spec.js on FE-core, so we should update the config to support spec.js only